### PR TITLE
fix a mistake in readme and error in generator

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,13 +1,13 @@
 example_id                                                                 | status | run_time        |
 -------------------------------------------------------------------------- | ------ | --------------- |
-./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:1:1]      | passed | 0.00259 seconds |
-./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:1:1:1]  | passed | 0.02612 seconds |
-./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:1:2:1]  | passed | 0.00441 seconds |
-./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:2:1]    | passed | 0.00209 seconds |
-./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:3:1]      | passed | 0.00764 seconds |
-./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:1:1] | passed | 0.00547 seconds |
-./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:2:1] | passed | 0.00593 seconds |
-./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:3:1] | passed | 0.00475 seconds |
-./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:2:1]   | passed | 0.00233 seconds |
-./spec/turbo_router/controllers/helper_test_controller_spec.rb[1:1:1:1]    | passed | 0.00347 seconds |
-./spec/turbo_router_spec.rb[1:1]                                           | passed | 0.00084 seconds |
+./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:1:1]      | passed | 0.0038 seconds  |
+./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:1:1:1]  | passed | 0.02759 seconds |
+./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:1:2:1]  | passed | 0.00392 seconds |
+./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:2:2:1]    | passed | 0.00181 seconds |
+./spec/turbo_router/controllers/custom_test_controller_spec.rb[1:3:1]      | passed | 0.00716 seconds |
+./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:1:1] | passed | 0.00435 seconds |
+./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:2:1] | passed | 0.00486 seconds |
+./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:1:3:1] | passed | 0.00391 seconds |
+./spec/turbo_router/controllers/default_test_controller_spec.rb[1:1:2:1]   | passed | 0.00202 seconds |
+./spec/turbo_router/controllers/helper_test_controller_spec.rb[1:1:1:1]    | passed | 0.00303 seconds |
+./spec/turbo_router_spec.rb[1:1]                                           | passed | 0.00082 seconds |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The above tables may not look that different, and they are not. This plugin simp
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "turbo_router"
+gem "turbo-router"
 ```
 
 And then execute:

--- a/lib/generators/turbo_router_generator.rb
+++ b/lib/generators/turbo_router_generator.rb
@@ -12,10 +12,6 @@ class TurboRouterGenerator < Rails::Generators::Base
     copy_file "turbo_router_content.erb", "app/views/layouts/turbo_router_content.erb"
   end
 
-  def copy_turbo_router_stream_template
-    copy_file "turbo_router_stream.erb", "app/views/layouts/turbo_router_stream.erb"
-  end
-
   def wrap_yield_call_in_application_template
     gsub_file "app/views/layouts/application.html.erb", /(<%=\s*yield\s*%>)/, "<%= render \"layouts/turbo_router_content\" do %>\\1<% end %>"
   end

--- a/spec/dummy/log/development.log
+++ b/spec/dummy/log/development.log
@@ -7051,3 +7051,280 @@ Processing by HelperTestController#test as HTML
 Completed 200 OK in 2ms (Views: 1.6ms | Allocations: 829)
 
 
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering custom_test/test.erb within layouts/turbo_router_content
+  Rendered custom_test/test.erb within layouts/turbo_router_content (Duration: 1.2ms | Allocations: 227)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.5ms | Allocations: 183)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 2.6ms | Allocations: 665)
+Completed 200 OK in 9ms (Views: 5.8ms | Allocations: 3071)
+
+
+Processing by CustomTestController#test_alt as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test_alt.erb within layouts/custom_page_layout
+  Rendered custom_test/test_alt.erb within layouts/custom_page_layout (Duration: 0.6ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 1.1ms | Allocations: 203)
+Completed 200 OK in 2ms (Views: 1.6ms | Allocations: 1031)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test.erb within layouts/custom_page_layout
+  Rendered custom_test/test.erb within layouts/custom_page_layout (Duration: 0.0ms | Allocations: 10)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.1ms | Allocations: 58)
+Completed 200 OK in 1ms (Views: 0.4ms | Allocations: 277)
+
+
+Processing by CustomTestController#turbo_stream_test_with_id as TURBO_STREAM
+  Rendering custom_test/test.erb
+  Rendered custom_test/test.erb (Duration: 0.0ms | Allocations: 10)
+Completed 200 OK in 1ms (Views: 0.1ms | Allocations: 636)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering default_test/test.erb within layouts/turbo_router_content
+  Rendered default_test/test.erb within layouts/turbo_router_content (Duration: 0.5ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 62)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 0.9ms | Allocations: 225)
+Completed 200 OK in 2ms (Views: 1.4ms | Allocations: 1193)
+
+
+Processing by DefaultTestController#test_alt as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test_alt.erb within layouts/application
+  Rendered default_test/test_alt.erb within layouts/application (Duration: 0.6ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 58)
+  Rendered layout layouts/application.html.erb (Duration: 1.7ms | Allocations: 538)
+Completed 200 OK in 3ms (Views: 2.2ms | Allocations: 1364)
+
+
+Processing by DefaultTestController#test_overridden as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering default_test/test_overridden.erb within layouts/custom_page_layout
+  Rendered default_test/test_overridden.erb within layouts/custom_page_layout (Duration: 0.4ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.5ms | Allocations: 125)
+Completed 200 OK in 1ms (Views: 1.0ms | Allocations: 674)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test.erb within layouts/application
+  Rendered default_test/test.erb within layouts/application (Duration: 0.0ms | Allocations: 10)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 59)
+  Rendered layout layouts/application.html.erb (Duration: 3.9ms | Allocations: 246)
+Completed 200 OK in 4ms (Views: 4.1ms | Allocations: 418)
+
+
+Processing by HelperTestController#test as HTML
+  Rendering helper_test/test.erb
+  Rendered helper_test/test.erb (Duration: 1.0ms | Allocations: 504)
+Completed 200 OK in 2ms (Views: 1.7ms | Allocations: 831)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering custom_test/test.erb within layouts/turbo_router_content
+  Rendered custom_test/test.erb within layouts/turbo_router_content (Duration: 0.5ms | Allocations: 227)
+  Rendered layouts/_turbo_router_content.erb (Duration: 7.4ms | Allocations: 3412)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 8.5ms | Allocations: 3897)
+Completed 500 Internal Server Error in 13ms (Allocations: 6361)
+
+
+Processing by CustomTestController#test_alt as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test_alt.erb within layouts/custom_page_layout
+  Rendered custom_test/test_alt.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.5ms | Allocations: 205)
+Completed 200 OK in 2ms (Views: 1.0ms | Allocations: 1129)
+
+
+Processing by CustomTestController#test as HTML
+Completed 500 Internal Server Error in 7ms (Allocations: 2305)
+
+
+Processing by CustomTestController#turbo_stream_test_with_id as */*
+Completed 500 Internal Server Error in 7ms (Allocations: 2301)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering default_test/test.erb within layouts/turbo_router_content
+  Rendered default_test/test.erb within layouts/turbo_router_content (Duration: 0.2ms | Allocations: 78)
+  Rendered layouts/_turbo_router_content.erb (Duration: 6.1ms | Allocations: 2614)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 6.6ms | Allocations: 2781)
+Completed 500 Internal Server Error in 8ms (Allocations: 3807)
+
+
+Processing by DefaultTestController#test_alt as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test_alt.erb within layouts/application
+  Rendered default_test/test_alt.erb within layouts/application (Duration: 0.2ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 6.2ms | Allocations: 2618)
+  Rendered layout layouts/application.html.erb (Duration: 7.1ms | Allocations: 3105)
+Completed 500 Internal Server Error in 8ms (Allocations: 3993)
+
+
+Processing by DefaultTestController#test_overridden as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering default_test/test_overridden.erb within layouts/custom_page_layout
+  Rendered default_test/test_overridden.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.4ms | Allocations: 125)
+Completed 200 OK in 1ms (Views: 0.8ms | Allocations: 767)
+
+
+Processing by DefaultTestController#test as HTML
+Completed 500 Internal Server Error in 7ms (Allocations: 2273)
+
+
+Processing by HelperTestController#test as HTML
+  Rendering helper_test/test.erb
+  Rendered helper_test/test.erb (Duration: 0.7ms | Allocations: 508)
+Completed 200 OK in 1ms (Views: 1.4ms | Allocations: 874)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering custom_test/test.erb within layouts/turbo_router_content
+  Rendered custom_test/test.erb within layouts/turbo_router_content (Duration: 0.6ms | Allocations: 227)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.3ms | Allocations: 183)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 1.4ms | Allocations: 665)
+Completed 200 OK in 6ms (Views: 3.8ms | Allocations: 3071)
+
+
+Processing by CustomTestController#test_alt as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test_alt.erb within layouts/custom_page_layout
+  Rendered custom_test/test_alt.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.4ms | Allocations: 203)
+Completed 200 OK in 1ms (Views: 0.9ms | Allocations: 1031)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test.erb within layouts/custom_page_layout
+  Rendered custom_test/test.erb within layouts/custom_page_layout (Duration: 0.0ms | Allocations: 10)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.1ms | Allocations: 58)
+Completed 200 OK in 0ms (Views: 0.3ms | Allocations: 277)
+
+
+Processing by CustomTestController#turbo_stream_test_with_id as TURBO_STREAM
+  Rendering custom_test/test.erb
+  Rendered custom_test/test.erb (Duration: 0.0ms | Allocations: 10)
+Completed 200 OK in 2ms (Views: 0.1ms | Allocations: 636)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering default_test/test.erb within layouts/turbo_router_content
+  Rendered default_test/test.erb within layouts/turbo_router_content (Duration: 0.3ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 62)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 0.5ms | Allocations: 225)
+Completed 200 OK in 2ms (Views: 1.1ms | Allocations: 1193)
+
+
+Processing by DefaultTestController#test_alt as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test_alt.erb within layouts/application
+  Rendered default_test/test_alt.erb within layouts/application (Duration: 0.2ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 58)
+  Rendered layout layouts/application.html.erb (Duration: 0.8ms | Allocations: 538)
+Completed 200 OK in 2ms (Views: 1.3ms | Allocations: 1364)
+
+
+Processing by DefaultTestController#test_overridden as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering default_test/test_overridden.erb within layouts/custom_page_layout
+  Rendered default_test/test_overridden.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.3ms | Allocations: 125)
+Completed 200 OK in 1ms (Views: 0.7ms | Allocations: 674)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test.erb within layouts/application
+  Rendered default_test/test.erb within layouts/application (Duration: 0.0ms | Allocations: 10)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 59)
+  Rendered layout layouts/application.html.erb (Duration: 4.1ms | Allocations: 246)
+Completed 200 OK in 4ms (Views: 4.4ms | Allocations: 418)
+
+
+Processing by HelperTestController#test as HTML
+  Rendering helper_test/test.erb
+  Rendered helper_test/test.erb (Duration: 0.7ms | Allocations: 504)
+Completed 200 OK in 1ms (Views: 1.3ms | Allocations: 831)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering custom_test/test.erb within layouts/turbo_router_content
+  Rendered custom_test/test.erb within layouts/turbo_router_content (Duration: 0.8ms | Allocations: 227)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.4ms | Allocations: 183)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 1.8ms | Allocations: 665)
+Completed 200 OK in 8ms (Views: 4.9ms | Allocations: 3071)
+
+
+Processing by CustomTestController#test_alt as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test_alt.erb within layouts/custom_page_layout
+  Rendered custom_test/test_alt.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.5ms | Allocations: 203)
+Completed 200 OK in 1ms (Views: 1.0ms | Allocations: 1031)
+
+
+Processing by CustomTestController#test as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering custom_test/test.erb within layouts/custom_page_layout
+  Rendered custom_test/test.erb within layouts/custom_page_layout (Duration: 0.0ms | Allocations: 10)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.1ms | Allocations: 58)
+Completed 200 OK in 1ms (Views: 0.4ms | Allocations: 277)
+
+
+Processing by CustomTestController#turbo_stream_test_with_id as TURBO_STREAM
+  Rendering custom_test/test.erb
+  Rendered custom_test/test.erb (Duration: 0.0ms | Allocations: 10)
+Completed 200 OK in 2ms (Views: 0.1ms | Allocations: 636)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/turbo_router_content.erb
+  Rendering default_test/test.erb within layouts/turbo_router_content
+  Rendered default_test/test.erb within layouts/turbo_router_content (Duration: 0.2ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 62)
+  Rendered layout layouts/turbo_router_content.erb (Duration: 0.5ms | Allocations: 225)
+Completed 200 OK in 2ms (Views: 1.0ms | Allocations: 1193)
+
+
+Processing by DefaultTestController#test_alt as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test_alt.erb within layouts/application
+  Rendered default_test/test_alt.erb within layouts/application (Duration: 0.2ms | Allocations: 77)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 58)
+  Rendered layout layouts/application.html.erb (Duration: 1.0ms | Allocations: 538)
+Completed 200 OK in 2ms (Views: 1.5ms | Allocations: 1364)
+
+
+Processing by DefaultTestController#test_overridden as HTML
+  Rendering layout layouts/custom_page_layout.erb
+  Rendering default_test/test_overridden.erb within layouts/custom_page_layout
+  Rendered default_test/test_overridden.erb within layouts/custom_page_layout (Duration: 0.2ms | Allocations: 77)
+  Rendered layout layouts/custom_page_layout.erb (Duration: 0.3ms | Allocations: 125)
+Completed 200 OK in 1ms (Views: 0.8ms | Allocations: 674)
+
+
+Processing by DefaultTestController#test as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering default_test/test.erb within layouts/application
+  Rendered default_test/test.erb within layouts/application (Duration: 0.0ms | Allocations: 10)
+  Rendered layouts/_turbo_router_content.erb (Duration: 0.1ms | Allocations: 58)
+  Rendered layout layouts/application.html.erb (Duration: 0.4ms | Allocations: 245)
+Completed 200 OK in 1ms (Views: 0.6ms | Allocations: 416)
+
+
+Processing by HelperTestController#test as HTML
+  Rendering helper_test/test.erb
+  Rendered helper_test/test.erb (Duration: 0.7ms | Allocations: 503)
+Completed 200 OK in 1ms (Views: 1.3ms | Allocations: 830)
+
+


### PR DESCRIPTION
This addresses:

https://github.com/WriterZephos/turbo-router/issues/1

and

https://github.com/WriterZephos/turbo-router/issues/2

I believe the file in the generator is no longer needed, so I just removed that code. 